### PR TITLE
First cut of the arche implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,275 @@
 > [Arche](https://en.wikipedia.org/wiki/Arche): A Greek word with primary senses "beginning", "origin", or "source of action"<br/>
 > [Arche](https://en.wikipedia.org/wiki/Arche_(mythology)): The ancient Greek muse of origins
 
+## Modules
+
+* [com.troy-west.arche/arche](https://github.com/troy-west/arche/tree/master/arche)
+
+  The base arche module. Provides an alia session wrapper that binds prepared statements to a session allowing them to be called using the standard alia execution functions. UDT's are also bound to the session.
+
+* [com.troy-west.arche/arche-hugsql](https://github.com/troy-west/arche/tree/master/arche-hugsql)
+
+  Uses hugsql to parse prepared statements from a String, File or map of statements.
+
+* [com.troy-west.arche/arche-integrant](https://github.com/troy-west/arche/tree/master/arche-integrant)
+
+  Provides an opinionated cassandra component (using [integrant](https://github.com/weavejester/integrant)) with lifecycle and dependency management of clusters and sessions.
+
+* [com.troy-west.arche/arche-component](https://github.com/troy-west/arche/tree/master/arche-component)
+
+  Provides an opinionated cassandra component (using [Component](https://github.com/stuartsierra/component)) with lifecycle and dependency management of clusters and sessions.
+
 ## Usage
 
-FIXME
+### Initial Setup
+
+Define your schema (and automate with [CCM-CLJ](https://github.com/SMX-LTD/ccm-clj))
+
+```cql
+CREATE TYPE asset (
+    code     text,
+    currency text,
+    notional text);
+
+CREATE TABLE trade (
+    id           text,
+    asset_basket map<text, frozen<asset>>,
+    PRIMARY KEY (id));
+
+CREATE TABLE client (
+    id   text,
+    name text,
+    PRIMARY KEY (id));
+```
+
+Example of creating a cluster:
+
+``` clojure
+(require '[ccm-clj.core :as ccm])
+(ccm/auto-cluster! "arche"
+                   "2.2.6"
+                   3
+                   [#"test-resources/test-keyspace\.cql"]
+                   {"sandbox" [#"test-resources/test-tables\.cql"]}
+                   19142)
+```
+
+### Usage without components
+
+Create a cluster instance using alia.
+
+```clojure
+(require '[qbits.alia :as alia])
+
+(def cluster (alia/cluster {:contact-points ["127.0.0.1"] :port 19142}))
+```
+
+Define some statements and UDT's.
+
+``` clojure
+
+;; note: the keys here define data reader tag names
+(def udts {::asset {:name "asset"}})
+
+(def statements {::insert-client "INSERT INTO client (id, name) VALUES (:id, :name)"
+                 ::select-client "SELECT * FROM client WHERE id = :id"
+                 ::insert-trade  "INSERT INTO trade (id, asset_basket) VALUES (:id, :\"asset-basket\")"
+                 ::select-trade  "SELECT id, asset_basket as \"asset-basket\" FROM trade where id = :id"})
+```
+
+Create an arche session with the cluster and the sandbox keyspace and pass the statements and UDT's as options.
+
+``` clojure
+(require '[com.troy-west.arche :as arche])
+
+(def session (arche/connect cluster "sandbox" {:statements statements :udts udts}))
+```
+
+Use new UDT encoders.
+
+``` clojure
+(arche/encode session ::asset {:code     "AB"
+                               :currency "GBP"
+                               :notional "12"}
+
+;; creates UDTValue instance
+;; #object[com.datastax.driver.core.UDTValue 0x29632e50 "{code:'AB',currency:'GBP',notional:'12'}"]
+```
+
+Use alia execute queries against the session.
+
+``` clojure
+(alia/execute session ::insert-client {:values {:id "id-1" :name "Carol"}})
+```
+
+### Parsing CQL prepared statements
+
+Arche-hugsql makes use of [HugSQL](https://www.hugsql.org/) to parse CQL prepared statements defined in CQL files, Strings or in a clojure map. It supports HugSQL [value parameters](https://www.hugsql.org/#param-value) and [identifier parameters](https://www.hugsql.org/#param-identifier). You can include the keywords in your CQL queries and the names will be properly quoted for you, automatically handling kebab cased keywords.
+
+The clq parsing is all done through the `prepared-statements` function. This function produces a map of prepared statement Strings with the identifiers and values quoted.
+
+#### maps example
+
+``` clojure
+(require '[com.troy-west.arche-hugsql :as arche-hugsql])
+
+(arche-hugsql/prepared-statements {:foo/bar "select :i:foo-bar from emp as where id_num = :id-num"})
+;; => {:foo/bar "select foo_bar as \"foo-bar\" from emp as where id_num = :\"id-num\""}
+```
+
+#### Strings example
+
+``` clojure
+(arche-hugsql/prepared-statements "--:name foo/bar \nselect :i:foo-bar from emp where id_num = :id-num")
+;; => {:foo/bar "select foo_bar as \"foo-bar\" from emp as where id_num = :\"id-num\""}
+```
+
+#### Files example
+
+Create a file in the resources directory called foo_bar.cql
+
+``` text
+--:name foo/bar
+select :i:foo-bar from emp where id = :id
+```
+
+Then cql file can be loaded like this:
+
+``` clojure
+(arche-hugsql/prepared-statements ["foo_bar.cql"])
+;; => {:foo/bar "select foo_bar as \"foo-bar\" from emp as where id_num = :\"id-num\""}
+```
+
+### [integrant](https://github.com/weavejester/integrant) arche component (recommended)
+
+Create prepared statements cql in `prepared/test.cql`
+
+``` text
+--:name arche/insert-client
+INSERT INTO client (id, name) VALUES (:id, :name)
+
+--:name arche/select-client
+SELECT * FROM client WHERE id = :id
+
+--:name arche/insert-trade
+INSERT INTO trade (id, asset_basket) VALUES (:id, :asset-basket)
+
+--:name arche/select-trade
+SELECT id, :i:asset-basket FROM trade where id = :id
+```
+
+Define the integrant cassandra configuration, can either be defined in a text file or in code.
+
+Note: The `ig/ref` calls can be replaced by integrant `#ref` tag to allow the config to be defined declaratively as EDN data.
+
+``` clojure
+(require '[integrant.core :as ig])
+(require '[com.troy-west.arche-integrant :as arche])
+
+(def cassandra-config
+  {[:arche/statements :test/statements-1] ["prepared/test.cql"]
+   [:arche/udts :test/udts-1]             {::asset {:name "asset"}}
+   [:cassandra/cluster :test/cluster-1]   {:contact-points ["127.0.0.1"] :port 19142}
+   [:cassandra/session :test/session-1]   {:keyspace   "sandbox"
+                                           :cluster    (ig/ref :test/cluster-1)
+                                           :statements (ig/ref :test/statements-1)
+                                           :udts       (ig/ref :test/udts-1)}})
+```
+
+Start the cassandra component.
+
+``` clojure
+(def cassandra (ig/init cassandra-config))
+```
+
+Execute some prepared statements using alia.
+
+``` clojure
+(require '[qbits.alia :as alia])
+
+(let [session (arche/session cassandra :test/session-1)]
+  (alia/execute session :arche/insert-client {:values {:id "id-1" :name "Carol"}})
+  (alia/execute session :arche/select-client {:values {:id "id-1"}})
+  (alia/execute session :arche/insert-trade
+    {:values {:id "trade-1"
+              :asset-basket {"long" (arche/encode session
+                                                  ::asset
+                                                  {:code     "AB"
+                                                   :currency "GBP"
+                                                   :notional "12"})
+                             "short" (arche/encode session
+                                                   ::asset
+                                                   {:code     "ZX"
+                                                    :currency "AUD"
+                                                    :notional "98"})}}}))
+```
+
+### [Component](https://github.com/stuartsierra/component) arche component
+
+Create prepared statements cql in `prepared/test.cql`
+
+``` text
+--:name arche/insert-client
+INSERT INTO client (id, name) VALUES (:id, :name)
+
+--:name arche/select-client
+SELECT * FROM client WHERE id = :id
+
+--:name arche/insert-trade
+INSERT INTO trade (id, asset_basket) VALUES (:id, :asset-basket)
+
+--:name arche/select-trade
+SELECT id, :i:asset-basket FROM trade where id = :id
+```
+
+Define the Component cassandra configuration, can either be defined in a text file or in code.
+
+Note: the data reader tags #arche/statements, #arche/cluster and #arche/session are made avalible by the `arche-component` library to make it possible to declaratively define the Component configuration as EDN data.
+
+``` clojure
+(require '[com.stuartsierra.component :as component])
+(require '[com.troy-west.arche-component :as arche])
+
+(def cassandra-config
+  {:test/statements-1 #arche/statements["prepared/test.cql"]
+   :test/udts-1       {::asset {:name "asset"}}
+   :test/cluster-1    #arche/cluster{:contact-points ["127.0.0.1"] :port 19142}
+   :test/session-1    #arche/session{:keyspace   "sandbox"
+                                     :cluster    :test/cluster-1
+                                     :statements :test/statements-1
+                                     :udts       :test/udts-1}})
+```
+
+Start the cassandra component.
+
+``` clojure
+(def cassandra (component/start (component/map->SystemMap cassandra-config))
+```
+
+Execute some prepared statements using alia.
+
+``` clojure
+(require '[qbits.alia :as alia])
+
+(let [session (arche/session cassandra :test/session-1)]
+  (alia/execute session :arche/insert-client {:values {:id "id-1" :name "Carol"}})
+  (alia/execute session :arche/select-client {:values {:id "id-1"}})
+  (alia/execute session :arche/insert-trade
+    {:values {:id "trade-1"
+              :asset-basket {"long" (arche/encode session
+                                                  ::asset
+                                                  {:code     "AB"
+                                                   :currency "GBP"
+                                                   :notional "12"})
+                             "short" (arche/encode session
+                                                   ::asset
+                                                   {:code     "ZX"
+                                                    :currency "AUD"
+                                                    :notional "98"})}}}))
+```
+
+## TODO
+Add tests
 
 ## License
 

--- a/arche-component/.gitignore
+++ b/arche-component/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/arche-component/CHANGELOG.md
+++ b/arche-component/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+
+## [Unreleased]
+### Changed
+- Add a new arity to `make-widget-async` to provide a different widget shape.
+
+## [0.1.1] - 2017-04-17
+### Changed
+- Documentation on how to make the widgets.
+
+### Removed
+- `make-widget-sync` - we're all async, all the time.
+
+### Fixed
+- Fixed widget maker to keep working when daylight savings switches over.
+
+## 0.1.0 - 2017-04-17
+### Added
+- Files from the new template.
+- Widget maker public API - `make-widget-sync`.
+
+[Unreleased]: https://github.com/your-name/arche-component/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/your-name/arche-component/compare/0.1.0...0.1.1

--- a/arche-component/LICENSE
+++ b/arche-component/LICENSE
@@ -1,0 +1,214 @@
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor to control, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/arche-component/README.md
+++ b/arche-component/README.md
@@ -1,0 +1,14 @@
+# arche-component
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2017 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/arche-component/doc/intro.md
+++ b/arche-component/doc/intro.md
@@ -1,0 +1,3 @@
+# Introduction to arche-component
+
+TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/arche-component/project.clj
+++ b/arche-component/project.clj
@@ -1,0 +1,5 @@
+(defproject com.troy-west/arche-component "0.1.0-SNAPSHOT"
+  :description "Arche system configuration using the the Component library."
+  :dependencies [[com.troy-west/arche "0.1.0-SNAPSHOT"]
+                 [com.troy-west/arche-hugsql "0.1.0-SNAPSHOT"]
+                 [com.stuartsierra/component "0.3.2"]])

--- a/arche-component/src/data_readers.clj
+++ b/arche-component/src/data_readers.clj
@@ -1,0 +1,3 @@
+{arche/statements com.troy-west.arche-component/create-statements
+ arche/cluster    com.troy-west.arche-component/create-cluster
+ arche/session    com.troy-west.arche-component/create-session}

--- a/arche-component/test-resources/logback-test.xml
+++ b/arche-component/test-resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} – %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.datastax.shaded.netty" level="INFO"/>
+    <logger name="org.apache.cassandra" level="INFO"/>
+    <logger name="com.datastax.driver" level="INFO"/>
+    <logger name="ccm-clj" level="INFO"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/arche-component/test-resources/prepared/test.cql
+++ b/arche-component/test-resources/prepared/test.cql
@@ -1,0 +1,11 @@
+--:name arche/insert-client
+INSERT INTO client (id, name) VALUES (:id, :name)
+
+--:name arche/select-client
+SELECT * FROM client WHERE id = :id
+
+--:name arche/insert-trade
+INSERT INTO trade (id, asset_basket) VALUES (:id, :asset-basket)
+
+--:name arche/select-trade
+SELECT id, :i:asset-basket FROM trade where id = :id

--- a/arche-component/test-resources/test-keyspace.cql
+++ b/arche-component/test-resources/test-keyspace.cql
@@ -1,0 +1,1 @@
+CREATE KEYSPACE sandbox with replication = {'class':'SimpleStrategy', 'replication_factor':3};

--- a/arche-component/test-resources/test-tables.cql
+++ b/arche-component/test-resources/test-tables.cql
@@ -1,0 +1,14 @@
+CREATE TYPE asset (
+    code     text,
+    currency text,
+    notional text);
+
+CREATE TABLE trade (
+    id           text,
+    asset_basket map<text, frozen<asset>>,
+    PRIMARY KEY (id));
+
+CREATE TABLE client (
+    id   text,
+    name text,
+    PRIMARY KEY (id));

--- a/arche-hugsql/.gitignore
+++ b/arche-hugsql/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/arche-hugsql/CHANGELOG.md
+++ b/arche-hugsql/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+
+## [Unreleased]
+### Changed
+- Add a new arity to `make-widget-async` to provide a different widget shape.
+
+## [0.1.1] - 2017-04-17
+### Changed
+- Documentation on how to make the widgets.
+
+### Removed
+- `make-widget-sync` - we're all async, all the time.
+
+### Fixed
+- Fixed widget maker to keep working when daylight savings switches over.
+
+## 0.1.0 - 2017-04-17
+### Added
+- Files from the new template.
+- Widget maker public API - `make-widget-sync`.
+
+[Unreleased]: https://github.com/your-name/arche-hugsql/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/your-name/arche-hugsql/compare/0.1.0...0.1.1

--- a/arche-hugsql/LICENSE
+++ b/arche-hugsql/LICENSE
@@ -1,0 +1,214 @@
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor to control, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/arche-hugsql/README.md
+++ b/arche-hugsql/README.md
@@ -1,0 +1,14 @@
+# arche-hugsql
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2017 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/arche-hugsql/doc/intro.md
+++ b/arche-hugsql/doc/intro.md
@@ -1,0 +1,3 @@
+# Introduction to arche-hugsql
+
+TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/arche-hugsql/project.clj
+++ b/arche-hugsql/project.clj
@@ -1,0 +1,3 @@
+(defproject com.troy-west/arche-hugsql "0.1.0-SNAPSHOT"
+  :description "Arche hugsql adaptor."
+  :dependencies [[com.layerware/hugsql "0.4.7"]])

--- a/arche-hugsql/src/com/troy_west/arche_hugsql.clj
+++ b/arche-hugsql/src/com/troy_west/arche_hugsql.clj
@@ -1,0 +1,94 @@
+(ns com.troy-west.arche-hugsql
+  (require [hugsql.core :as hugsql]))
+
+(defn resolve-value
+  [k]
+  (str ":\"" (name (:name k)) "\""))
+
+(defn resolve-identifier
+  [k]
+  (let [n (name (:name k))]
+    (str (clojure.string/replace n #"-" "_") " as \"" n "\"")))
+
+(defmulti resolve-key :type)
+
+(defmethod resolve-key :default [k] k)
+(defmethod resolve-key :v [k] (resolve-value k))
+(defmethod resolve-key :value [k] (resolve-value k))
+(defmethod resolve-key :i [k] (resolve-identifier k))
+(defmethod resolve-key :identifier [k] (resolve-identifier k))
+
+(defn resolve-keys
+  [sql-template]
+  (apply str (map resolve-key sql-template)))
+
+(defn prepared-statements-from-pdefs
+  [pdefs]
+  (->> (for [{:keys [hdr sql] :as pdef} pdefs]
+         [(keyword (first (:name hdr))) (resolve-keys sql)])
+       (into {})))
+
+(defn prepared-statements-from-string
+  "Same as load-prepared-statements but takes a string as an input rather than a file."
+  [s]
+  (prepared-statements-from-pdefs
+   (hugsql/parsed-defs-from-string s)))
+
+(defn prepared-statements-from-map
+  "Same as load-prepared-statements but takes a map as an input rather than a file.
+
+  i.e.
+    {:foo/bar \"select :i:foo-bar from emp as where id = :id\"}
+
+  becomes
+
+    {:foo/bar \"select foo_bar as \\\"foo-bar\\\" from emp as where id = :\\\"id\\\"\"}
+  "
+  [m]
+  (->> (map identity m)
+       flatten
+       (map #(if (keyword? %)
+               (str "--:name " (if (namespace %)
+                                 (str (namespace %) "/" (name %))
+                                 (name %)))
+               %))
+       (clojure.string/join "\n")
+       prepared-statements-from-string))
+
+(defn load-prepared-statements
+  "Reads named CQL statements (using Hugsql formatting) and returns
+   a map of key (statement name) -> statement string.
+
+   The statement strings will have any Hugsql Values and Identifiers
+   quoted.
+
+   i.e.
+     --:name foo/bar
+     select :i:foo-bar from emp where id = :id
+
+   becomes
+
+     {:foo/bar \"select foo_bar as \\\"foo-bar\\\" from emp where id = :\\\"id\\\"\"}
+
+  See: https://www.hugsql.org/
+       https://www.hugsql.org/#param-value
+       https://www.hugsql.org/#param-identifier
+
+  Note: The other more dynamic features of Hugsql are not supported here,
+        list, tuples, snippets.
+  "
+  [& files]
+  (apply merge
+         (map (comp prepared-statements-from-pdefs
+                    hugsql/parsed-defs-from-file)
+              files)))
+
+(defn prepared-statements
+  "Convenience function that dispatches to the appropriate statement constructor
+
+   arg - a map, String or a sequence of file paths."
+  [arg]
+  (cond
+    (map? arg)        (prepared-statements-from-map arg)
+    (string? arg)     (prepared-statements-from-string arg)
+    (sequential? arg) (apply load-prepared-statements arg)))

--- a/arche-hugsql/test-resources/prepared/test.cql
+++ b/arche-hugsql/test-resources/prepared/test.cql
@@ -1,0 +1,5 @@
+--:name foo/bar
+select :i:foo-bar from emp where id = :id
+
+--:name foo/baz
+select * from :i:foo-baz

--- a/arche-hugsql/test/arche_hugsql/core_test.clj
+++ b/arche-hugsql/test/arche_hugsql/core_test.clj
@@ -1,0 +1,7 @@
+(ns arche-hugsql.core-test
+  (:require [clojure.test :refer :all]
+            [arche-hugsql.core :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))

--- a/arche-integrant/.gitignore
+++ b/arche-integrant/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/arche-integrant/CHANGELOG.md
+++ b/arche-integrant/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+
+## [Unreleased]
+### Changed
+- Add a new arity to `make-widget-async` to provide a different widget shape.
+
+## [0.1.1] - 2017-04-17
+### Changed
+- Documentation on how to make the widgets.
+
+### Removed
+- `make-widget-sync` - we're all async, all the time.
+
+### Fixed
+- Fixed widget maker to keep working when daylight savings switches over.
+
+## 0.1.0 - 2017-04-17
+### Added
+- Files from the new template.
+- Widget maker public API - `make-widget-sync`.
+
+[Unreleased]: https://github.com/your-name/arche-integrant/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/your-name/arche-integrant/compare/0.1.0...0.1.1

--- a/arche-integrant/LICENSE
+++ b/arche-integrant/LICENSE
@@ -1,0 +1,214 @@
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor to control, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/arche-integrant/README.md
+++ b/arche-integrant/README.md
@@ -1,0 +1,14 @@
+# arche-integrant
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2017 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/arche-integrant/doc/intro.md
+++ b/arche-integrant/doc/intro.md
@@ -1,0 +1,3 @@
+# Introduction to arche-integrant
+
+TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/arche-integrant/project.clj
+++ b/arche-integrant/project.clj
@@ -1,0 +1,5 @@
+(defproject com.troy-west/arche-integrant "0.1.0-SNAPSHOT"
+  :description "Arche system configuration using the the Integrant library."
+  :dependencies [[com.troy-west/arche "0.1.0-SNAPSHOT"]
+                 [com.troy-west/arche-hugsql "0.1.0-SNAPSHOT"]
+                 [integrant "0.3.3"]])

--- a/arche-integrant/src/com/troy_west/arche_integrant.clj
+++ b/arche-integrant/src/com/troy_west/arche_integrant.clj
@@ -1,0 +1,37 @@
+(ns com.troy-west.arche-integrant
+  (:require [integrant.core :as ig]
+            [com.troy-west.arche :as arche]
+            [com.troy-west.arche-hugsql :as arche-hugsql]
+            [qbits.alia :as alia]))
+
+(defmethod ig/init-key :cassandra/cluster
+  [_ config]
+  (alia/cluster config))
+
+(defmethod ig/init-key :cassandra/session
+  [_ config]
+  (arche/init-session config))
+
+(defmethod ig/init-key :arche/statements
+  [_ config]
+  (arche-hugsql/prepared-statements config))
+
+(defmethod ig/init-key :arche/udts
+  [_ config]
+  (identity config))
+
+(defmethod ig/halt-key! :cassandra/cluster
+  [_ cluster]
+  (alia/shutdown cluster))
+
+(defmethod ig/halt-key! :cassandra/session
+  [_ session]
+  (alia/shutdown session))
+
+(defn session
+  [cassandra session-key]
+  (second (ig/find-derived-1 cassandra session-key)))
+
+(defn encode
+  [session udts-key value]
+  (arche/encode session udts-key value))

--- a/arche-integrant/test-resources/logback-test.xml
+++ b/arche-integrant/test-resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} – %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.datastax.shaded.netty" level="INFO"/>
+    <logger name="org.apache.cassandra" level="INFO"/>
+    <logger name="com.datastax.driver" level="INFO"/>
+    <logger name="ccm-clj" level="INFO"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/arche-integrant/test-resources/prepared/test.cql
+++ b/arche-integrant/test-resources/prepared/test.cql
@@ -1,0 +1,11 @@
+--:name arche/insert-client
+INSERT INTO client (id, name) VALUES (:id, :name)
+
+--:name arche/select-client
+SELECT * FROM client WHERE id = :id
+
+--:name arche/insert-trade
+INSERT INTO trade (id, asset_basket) VALUES (:id, :asset-basket)
+
+--:name arche/select-trade
+SELECT id, :i:asset-basket FROM trade where id = :id

--- a/arche-integrant/test-resources/test-keyspace.cql
+++ b/arche-integrant/test-resources/test-keyspace.cql
@@ -1,0 +1,1 @@
+CREATE KEYSPACE sandbox with replication = {'class':'SimpleStrategy', 'replication_factor':3};

--- a/arche-integrant/test-resources/test-tables.cql
+++ b/arche-integrant/test-resources/test-tables.cql
@@ -1,0 +1,14 @@
+CREATE TYPE asset (
+    code     text,
+    currency text,
+    notional text);
+
+CREATE TABLE trade (
+    id           text,
+    asset_basket map<text, frozen<asset>>,
+    PRIMARY KEY (id));
+
+CREATE TABLE client (
+    id   text,
+    name text,
+    PRIMARY KEY (id));

--- a/arche/.gitignore
+++ b/arche/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/arche/CHANGELOG.md
+++ b/arche/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+
+## [Unreleased]
+### Changed
+- Add a new arity to `make-widget-async` to provide a different widget shape.
+
+## [0.1.1] - 2017-04-17
+### Changed
+- Documentation on how to make the widgets.
+
+### Removed
+- `make-widget-sync` - we're all async, all the time.
+
+### Fixed
+- Fixed widget maker to keep working when daylight savings switches over.
+
+## 0.1.0 - 2017-04-17
+### Added
+- Files from the new template.
+- Widget maker public API - `make-widget-sync`.
+
+[Unreleased]: https://github.com/your-name/arche/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/your-name/arche/compare/0.1.0...0.1.1

--- a/arche/LICENSE
+++ b/arche/LICENSE
@@ -1,0 +1,214 @@
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor to control, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/arche/README.md
+++ b/arche/README.md
@@ -1,0 +1,14 @@
+# arche
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2017 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/arche/doc/intro.md
+++ b/arche/doc/intro.md
@@ -1,0 +1,3 @@
+# Introduction to arche
+
+TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/arche/project.clj
+++ b/arche/project.clj
@@ -1,0 +1,5 @@
+(defproject com.troy-west/arche "0.1.0-SNAPSHOT"
+  :description "Arche: Cassandra Clojure Cluster and Session Management with Alia"
+  :url "http://www.troy-west.com/arche"
+  :license {:name "Eclipse Public License"
+            :url  "http://www.eclipse.org/legal/epl-v10.html"})

--- a/arche/src/com/troy_west/arche.clj
+++ b/arche/src/com/troy_west/arche.clj
@@ -1,0 +1,123 @@
+(ns com.troy-west.arche
+  (:require [qbits.alia :as alia]
+            [qbits.alia.codec.default :as codec.default]
+            [qbits.alia.udt :as alia.udt])
+  (:import (com.datastax.driver.core Session
+                                     BoundStatement
+                                     SimpleStatement)))
+
+(definterface IBindable
+  (^com.datastax.driver.core.BoundStatement bind [statement-store]))
+
+(defn bindable-statement
+  [statement-key values codec]
+  (let [q            ""
+        ;; hack since ealier versions don't have a way to get paging state
+        paging-state (atom nil)]
+    (proxy [SimpleStatement IBindable] [q]
+      (bind [statement-store]
+        (let [statement    (alia/bind (get statement-store statement-key)
+                                      values
+                                      codec)]
+          (alia/set-statement-options! statement
+                                       (.getRoutingKey this nil nil)
+                                       (.getRetryPolicy this)
+                                       (.isTracing this)
+                                       (.isIdempotent this)
+                                       (some-> (.getConsistencyLevel this)
+                                               str clojure.string/lower-case keyword)
+                                       (some-> (.getSerialConsistencyLevel this)
+                                               str clojure.string/lower-case keyword)
+                                       (.getFetchSize this)
+                                       (.getDefaultTimestamp this)
+                                       @paging-state
+                                       (let [timeout (.getReadTimeoutMillis this)]
+                                         (when (> timeout 0) timeout)))
+          statement))
+      (setPagingState [ps] (reset! paging-state ps))
+      (getQueryString [] ""))))
+
+(extend-protocol alia/PStatement
+  clojure.lang.Keyword
+  (query->statement [q values codec]
+    (bindable-statement q values codec)))
+
+(defprotocol IExecutable
+  (build-executable [this statement-store]))
+
+(extend-protocol IExecutable
+  IBindable
+  (build-executable [this statement-store]
+    (.bind this statement-store))
+
+  Object
+  (build-executable [this _]
+    this))
+
+(defn wrap-session
+  [session {:keys [statements codecs]
+            :or {statements {}
+                 codecs     {}} :as state}]
+  (proxy [Session clojure.lang.ILookup] []
+    (close [] (.close session))
+    (closeAsync [] (.closeAsync session))
+    (execute
+      ([q] (.execute session (build-executable q statements)))
+      ([q vs] (.execute session q vs))
+      ([q v & vs] (.execute session q (conj vs v))))
+    (executeAsync
+      ([q] (.executeAsync session (build-executable q statements)))
+      ([q vs] (.executeAsync session q vs))
+      ([q v & vs] (.executeAsync session q (conj vs v))))
+    (getCluster [] (.getCluster session))
+    (getLoggedKeyspace [] (.getLoggedKeyspace session))
+    (getState [] (.getState session))
+    (init [] (.init session))
+    (initAsync [] (.initAsync session))
+    (isClosed [] (.isClosed session))
+    (prepare [q] (.prepare session q))
+    (prepareAsync [q] (.prepareAsync q))
+
+    (valAt [k] (.valAt state k))))
+
+(defn prepare-statements
+  [session statements]
+  (reduce-kv (fn [ret k v]
+               (assoc ret k (alia/prepare session v)))
+             {}
+             statements))
+
+(defn prepare-encoders
+  [session udts]
+  (reduce-kv (fn [ret k v]
+               (assoc ret k (alia.udt/encoder session
+                                              (:name v)
+                                              (or (:codec v) codec.default/codec))))
+             {}
+             udts))
+
+(defn init-session
+  "Initialise a new session binding prepared statements and udts to the session."
+  [{:keys [keyspace cluster statements udts] :as config}]
+  (let [session             (if keyspace
+                              (alia/connect cluster keyspace)
+                              (alia/connect cluster))
+        prepared-statements (prepare-statements session statements)
+        prepared-udts       (prepare-encoders session udts)]
+    (wrap-session session
+                  (merge config
+                         {:statements prepared-statements
+                          :udts       prepared-udts}))))
+
+(defn encode
+  [session udts-key value]
+  ((-> session :udts udts-key) value))
+
+(defn connect
+  ([cluster keyspace {:keys [statements udts]}]
+   (init-session {:cluster    cluster
+                  :keyspace   keyspace
+                  :statements statements
+                  :udts       udts}))
+  ([cluster options]
+   (connect cluster nil options)))

--- a/arche/test-resources/logback-test.xml
+++ b/arche/test-resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} – %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.datastax.shaded.netty" level="INFO"/>
+    <logger name="org.apache.cassandra" level="INFO"/>
+    <logger name="com.datastax.driver" level="INFO"/>
+    <logger name="ccm-clj" level="INFO"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/arche/test-resources/prepared/test.cql
+++ b/arche/test-resources/prepared/test.cql
@@ -1,0 +1,11 @@
+--:name arche/insert-client
+INSERT INTO client (id, name) VALUES (:id, :name)
+
+--:name arche/select-client
+SELECT * FROM client WHERE id = :id
+
+--:name arche/insert-trade
+INSERT INTO trade (id, asset_basket) VALUES (:id, :asset-basket)
+
+--:name arche/select-trade
+SELECT id, :i:asset-basket FROM trade where id = :id

--- a/arche/test-resources/test-keyspace.cql
+++ b/arche/test-resources/test-keyspace.cql
@@ -1,0 +1,1 @@
+CREATE KEYSPACE sandbox with replication = {'class':'SimpleStrategy', 'replication_factor':3};

--- a/arche/test-resources/test-tables.cql
+++ b/arche/test-resources/test-tables.cql
@@ -1,0 +1,14 @@
+CREATE TYPE asset (
+    code     text,
+    currency text,
+    notional text);
+
+CREATE TABLE trade (
+    id           text,
+    asset_basket map<text, frozen<asset>>,
+    PRIMARY KEY (id));
+
+CREATE TABLE client (
+    id   text,
+    name text,
+    PRIMARY KEY (id));

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,19 @@
-(defproject com.troy-west/arche "0.1.0-SNAPSHOT"
+(defproject com.troy-west/arche-all "0.1.0-SNAPSHOT"
   :description "Arche: Cassandra Clojure Cluster and Session Management with Alia"
   :url "http://www.troy-west.com/arche"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]])
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
+
+  :plugins [[lein-modules "0.3.11"]]
+  :middleware [lein-modules.plugin/middleware]
+
+  :profiles     {:dev {:source-paths   ["dev"]
+                       :resource-paths ["test-resources"]
+                       :dependencies   [[com.smxemail/ccm-clj "1.1.0"]
+                                        [ch.qos.logback/logback-classic "1.1.8"]]}}
+  :modules {:inherited {:dependencies [[org.clojure/clojure "_"]
+                                       [cc.qbits/alia "_"]]
+                        :resource-paths ["test-resources"]}
+            :versions {org.clojure/clojure "1.8.0"
+                       cc.qbits/alia "4.0.0-beta9"
+                       com.troy-west/arche "0.1.0-SNAPSHOT"}})

--- a/src/com/troy-west/arche.clj
+++ b/src/com/troy-west/arche.clj
@@ -1,1 +1,0 @@
-(ns com.troy-west.arche)

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} – %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.datastax.shaded.netty" level="INFO"/>
+    <logger name="org.apache.cassandra" level="INFO"/>
+    <logger name="com.datastax.driver" level="INFO"/>
+    <logger name="ccm-clj" level="INFO"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/test-resources/test-keyspace.cql
+++ b/test-resources/test-keyspace.cql
@@ -1,0 +1,1 @@
+CREATE KEYSPACE sandbox with replication = {'class':'SimpleStrategy', 'replication_factor':3};

--- a/test-resources/test-tables.cql
+++ b/test-resources/test-tables.cql
@@ -1,0 +1,14 @@
+CREATE TYPE asset (
+    code     text,
+    currency text,
+    notional text);
+
+CREATE TABLE trade (
+    id           text,
+    asset_basket map<text, frozen<asset>>,
+    PRIMARY KEY (id));
+
+CREATE TABLE client (
+    id   text,
+    name text,
+    PRIMARY KEY (id));


### PR DESCRIPTION
Includes four modules:
* arche
  - The base arche module. Provides an alia session wrapper that binds prepared statements to a session allowing them to be called using the standard alia execution functions. UDT's are also bound to the session.
* arche-hugsql
  - Uses hugsql to parse prepared statements from a String, File or map of statements.
* arche-integrant
  - Provides an opinionated cassandra component (using integrant) with lifecycle and dependency management of clusters and sessions.
* arche-component
  - Provides an opinionated cassandra component (using Component) with lifecycle and dependency management of clusters and sessions.